### PR TITLE
Adds a post about the SVM experiment

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,3 +10,6 @@ authors:
   andromeda:
     name: Andromeda Yelton
     github: thatandromeda
+  mjbernha:
+    name: Matthew Bernhardt
+    github: matt-bernhardt

--- a/_posts/2018-06-29-precog-an-svm.md
+++ b/_posts/2018-06-29-precog-an-svm.md
@@ -1,0 +1,6 @@
+---
+title: "Precog: an experiment with support vector machines"
+author: mjbernha
+---
+
+This post is at least a year late, but I wanted to try and finish it before too much time lapses.


### PR DESCRIPTION
This is a work in progress - the first commit just sets up the framework for me to be an author, and defines a stub post about the SVM experiment that I did last year.

My intent is to expand this into a short post describing what that work was, so i don't lose even more of it to my failing memory.